### PR TITLE
Change optimiser start point

### DIFF
--- a/pyseer
+++ b/pyseer
@@ -151,8 +151,10 @@ def binary(p, k, m, af, pret, lrtt, null_res):
     old_stdout = sys.stdout
     sys.stdout = open(os.devnull, "w")
     try:
-        # try first bfgs optimization
-        res1 = mod1.fit(method='bfgs')
+        # try first bfgs optimization, but only if it works in a few iterations
+        start_vec = np.ones(df.shape[1])
+        start_vec[0] = np.log(np.mean(p.values)/(1-np.mean(p.values)))
+        res1 = mod1.fit(start_params=start_vec, method='bfgs', maxiter=20)
         if not res1.mle_retvals['converged']:
             # fallback to Newton-Raphson
             res1 = mod1.fit(method='newton')


### PR DESCRIPTION
See e42b16d for details. The results of tests for issue #5 suggest this is the best strategy.
I think it's worth keep BFGS rather than dropping in entirely, as I think it fits less often than usual on the test dataset.