### PR TITLE
Avoid crashes while filtering variants for enet

### DIFF
--- a/pyseer/enet.py
+++ b/pyseer/enet.py
@@ -343,11 +343,14 @@ def correlation_filter(p, all_vars, quantile_filter = 0.25):
     for row_idx in tqdm(range(all_vars.shape[0]), unit="variants"):
         k = all_vars.getrow(row_idx)
         k_mean = csr_matrix.mean(k)
-
-        ab = k.dot(b) - np.sum(k_mean * b)
-        sum_a_squared = k.dot(k.transpose()).data[0] - 2*k_mean*csr_matrix.sum(k) + pow(k_mean, 2) * all_vars.shape[1]
-        cor = np.abs(ab / np.sqrt(sum_a_squared * sum_b_squared))
-        correlations.append(cor)
+        if k_mean == 0:
+            # avoid crashes due to an empty sparse vector
+            correlations.append([np.nan])
+        else:
+            ab = k.dot(b) - np.sum(k_mean * b)
+            sum_a_squared = k.dot(k.transpose()).data[0] - 2*k_mean*csr_matrix.sum(k) + pow(k_mean, 2) * all_vars.shape[1]
+            cor = np.abs(ab / np.sqrt(sum_a_squared * sum_b_squared))
+            correlations.append(cor)
 
     cor_filter = np.nonzero(correlations > np.percentile(correlations, quantile_filter*100))[0]
     return(cor_filter)

--- a/tests/enet_test.py
+++ b/tests/enet_test.py
@@ -238,6 +238,10 @@ class TestCorrelationFilter(unittest.TestCase):
         a = csr_matrix(a.T)
         f = correlation_filter(p, a, 0.75)
         self.assertTrue(abs(f - np.array([0, 5])).max() < 1E-7)
+        # variant absent in all
+        a = csr_matrix(np.zeros(a.T.shape))
+        f = correlation_filter(p, a, 0.75)
+        self.assertEqual(f.shape[0], 0)
 
     def test_filter_continuous(self):
         p = pd.read_csv(P,
@@ -247,6 +251,10 @@ class TestCorrelationFilter(unittest.TestCase):
         a = csr_matrix(a.T)
         f = correlation_filter(p, a, 0.75)
         self.assertTrue(abs(f - np.array([1, 2])).max() < 1E-7)
+        # variant absent in all
+        a = csr_matrix(np.zeros(a.T.shape))
+        f = correlation_filter(p, a, 0.75)
+        self.assertEqual(f.shape[0], 0)
 
 
 class TestFitEnet(unittest.TestCase):


### PR DESCRIPTION
Variants absent in all samples lead to crashes due to the
implementations of sparse matrices.

Tentatively fixes #114