### PR TITLE
Fix summarize_annotations when using elastic net

### DIFF
--- a/scripts/summarise_annotations.py
+++ b/scripts/summarise_annotations.py
@@ -46,7 +46,10 @@ if __name__ == "__main__":
         for line in anot_file:
             anot_fields = line.rstrip().split("\t")
             af = float(anot_fields[1])
-            pvalue = float(anot_fields[3])
+            if anot_fields[3] == "":
+                pvalue = float(anot_fields[2])
+            else:
+                pvalue = float(anot_fields[3])
             beta = abs(float(anot_fields[4]))
             # double check that there are actual hits here
             if anot_fields[-1].count(';') == 0:


### PR DESCRIPTION
Using output from the elastic net model, I was getting an error because no p-value correcting for population structure was reported.  This change allows `summarize_annotations` to use the p-value that doesn't correct for population structure in that case.