### PR TITLE
Enet covariates

### DIFF
--- a/pyseer/enet_predict.py
+++ b/pyseer/enet_predict.py
@@ -124,7 +124,7 @@ def main():
             for covariate in cov:
                 pred_beta = model_dict.pop(covariate, (0, 0))
                 if pred_beta[1] != 0:
-                    predictions += (cov[covariate] * pred_beta[1]).reshape(-1, 1)
+                    predictions += (cov[covariate] * pred_beta[1]).values.reshape(-1, 1)
 
     # Read in lineages
     if options.lineage_clusters:

--- a/tests/run_test.sh
+++ b/tests/run_test.sh
@@ -78,6 +78,7 @@ python ../enet_predict-runner.py --vcf variants.vcf.gz enet_vcf_model.pkl subset
 
 # test the scripts folder
 python ../enet_predict-runner.py --vcf variants.vcf.gz enet_vcf_model.pkl subset.samples_list > /dev/null 2> /dev/null || die "Enet predict"
+python ../enet_predict-runner.py --vcf variants.vcf.gz enet_vcf_model.pkl subset.samples_list --covariates covariates.txt --use-covariates 2q 3 > /dev/null 2> /dev/null || die "Enet predict w/ covariates"
 python ../scripts/count_patterns.py patterns.txt > /dev/null 2> /dev/null || die "Count patterns"
 python ../scripts/phylogeny_distance.py tree.nwk > /dev/null 2> /dev/null || die "Tree distances"
 python ../scripts/phylogeny_distance.py tree.nwk --lmm > /dev/null 2> /dev/null || die "Tree distances (C)"


### PR DESCRIPTION
We encountered a crash when using enet_predict and covariates. Unclear why it only gets triggered on some datasets (have not had the time to look in detail). But the proposed change fixes the problem and does not cause a regression.